### PR TITLE
Make options in context when calling targetOrigin function

### DIFF
--- a/lib/door.js
+++ b/lib/door.js
@@ -166,6 +166,7 @@
         return;
       }
 
+      var options = this.options;
       var data;
       try {
         data = JSON.parse(messageEvent.data);
@@ -206,7 +207,6 @@
 
       // messageEvent.origin is 'null' in case of file:// url.
       // For such environment we use the default targetOrigin
-      var options = this.options;
       function targetOrigin() {
         return messageEvent.origin === 'null'
           ? options.targetOrigin


### PR DESCRIPTION
Was causing a `Uncaught TypeError: Cannot read property 'targetOrigin' of undefined` exception on load.
