### PR TITLE
Only stub Array.prototype.toJSON if it is native

### DIFF
--- a/lib/safe_json.js
+++ b/lib/safe_json.js
@@ -3,9 +3,13 @@ define(function () {
   function safeStringify () {
     /* jshint ignore:start */
     var arrayToJSON = Array.prototype.toJSON;
-    Array.prototype.toJSON = undefined;
+    if (arrayToJSON) {
+      Array.prototype.toJSON = undefined;
+    }
     var result = JSON.stringify.apply(this, arguments);
-    Array.prototype.toJSON = arrayToJSON;
+    if (arrayToJSON) {
+      Array.prototype.toJSON = arrayToJSON;
+    }
     return result;
     /* jshint ignore:end */
   }
@@ -16,4 +20,3 @@ define(function () {
   };
 
 });
-


### PR DESCRIPTION
Previously `toJSON` was being added to the `Array.prototype` even if this didn't exist natively in the browser.